### PR TITLE
Fix max result size no content length

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -77,7 +77,7 @@ public final class EntityUtils {
      */
     public static void consumeQuietly(final HttpEntity entity) {
         try {
-            consume(entity);
+          consume(entity);
         } catch (final IOException ignore) {
             // Ignore exception
         }
@@ -116,8 +116,8 @@ public final class EntityUtils {
      *
      * @param entity the entity to read from=
      * @return byte array containing the entity content. May be null if
-     * {@link HttpEntity#getContent()} is null.
-     * @throws IOException              if an error occurs reading the input stream
+     *   {@link HttpEntity#getContent()} is null.
+     * @throws IOException if an error occurs reading the input stream
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity) throws IOException {
@@ -140,12 +140,12 @@ public final class EntityUtils {
     /**
      * Reads the contents of an entity and return it as a byte array.
      *
-     * @param entity          the entity to read from=
+     * @param entity the entity to read from=
      * @return byte array containing the entity content. May be null if
-     * {@link HttpEntity#getContent()} is null.
+     *   {@link HttpEntity#getContent()} is null.
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
-     * @throws IOException              if an error occurs reading the input stream
+     * @throws IOException if an error occurs reading the input stream
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity, final int maxResultLength) throws IOException {
@@ -167,7 +167,7 @@ public final class EntityUtils {
     }
 
     private static CharArrayBuffer toCharArrayBuffer(final InputStream inStream, final int contentLength,
-                                                     final Charset charset, final int maxResultLength) throws IOException {
+            final Charset charset, final int maxResultLength) throws IOException {
         Args.notNull(inStream, "InputStream");
         Args.positive(maxResultLength, "maxResultLength");
         final Charset actualCharset = charset == null ? DEFAULT_CHARSET : charset;
@@ -195,9 +195,9 @@ public final class EntityUtils {
                 ContentType.MULTIPART_FORM_DATA,
                 ContentType.TEXT_HTML,
                 ContentType.TEXT_PLAIN,
-                ContentType.TEXT_XML};
+                ContentType.TEXT_XML };
         final HashMap<String, ContentType> map = new HashMap<>();
-        for (final ContentType contentType : contentTypes) {
+        for (final ContentType contentType: contentTypes) {
             map.put(contentType.getMimeType(), contentType);
         }
         CONTENT_TYPE_MAP = Collections.unmodifiableMap(map);
@@ -228,16 +228,16 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity         must not be null
+     * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity,
-     *                       or if the entity provided charset is invalid or not available.
+     * or if the entity provided charset is invalid or not available.
      * @return the entity content as a String. May be null if
-     * {@link HttpEntity#getContent()} is null.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     *   {@link HttpEntity#getContent()} is null.
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named entity's charset is not available in
-     *                                                      this instance of the Java virtual machine and no defaultCharset is provided.
+     * this instance of the Java virtual machine and no defaultCharset is provided.
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset) throws IOException, ParseException {
@@ -249,18 +249,18 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity          must not be null
-     * @param defaultCharset  character set to be applied if none found in the entity,
-     *                        or if the entity provided charset is invalid or not available.
+     * @param entity must not be null
+     * @param defaultCharset character set to be applied if none found in the entity,
+     * or if the entity provided charset is invalid or not available.
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return the entity content as a String. May be null if
-     * {@link HttpEntity#getContent()} is null.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     *   {@link HttpEntity#getContent()} is null.
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named entity's charset is not available in
-     *                                                      this instance of the Java virtual machine and no defaultCharset is provided.
+     * this instance of the Java virtual machine and no defaultCharset is provided.
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset, final int maxResultLength) throws IOException, ParseException {
@@ -288,15 +288,15 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity         must not be null
+     * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity
      * @return the entity content as a String. May be null if
-     * {@link HttpEntity#getContent()} is null.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     *   {@link HttpEntity#getContent()} is null.
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     *                                                      this instance of the Java virtual machine
+     * this instance of the Java virtual machine
      */
     public static String toString(
             final HttpEntity entity, final String defaultCharset) throws IOException, ParseException {
@@ -308,17 +308,17 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity          must not be null
-     * @param defaultCharset  character set to be applied if none found in the entity
+     * @param entity must not be null
+     * @param defaultCharset character set to be applied if none found in the entity
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return the entity content as a String. May be null if
-     * {@link HttpEntity#getContent()} is null.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     *   {@link HttpEntity#getContent()} is null.
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     *                                                      this instance of the Java virtual machine
+     * this instance of the Java virtual machine
      */
     public static String toString(
             final HttpEntity entity, final String defaultCharset, final int maxResultLength) throws IOException, ParseException {
@@ -332,11 +332,11 @@ public final class EntityUtils {
      *
      * @param entity the entity to convert to a string; must not be null
      * @return String containing the content.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     *                                                      this instance of the Java virtual machine
+     * this instance of the Java virtual machine
      */
     public static String toString(final HttpEntity entity) throws IOException, ParseException {
         return toString(entity, DEFAULT_ENTITY_RETURN_MAX_LENGTH);
@@ -347,15 +347,15 @@ public final class EntityUtils {
      * The content is converted using the character set from the entity (if any),
      * failing that, "ISO-8859-1" is used.
      *
-     * @param entity          the entity to convert to a string; must not be null
+     * @param entity the entity to convert to a string; must not be null
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return String containing the content.
-     * @throws ParseException                               if header elements cannot be parsed
-     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException                                  if an error occurs reading the input stream
+     * @throws ParseException if header elements cannot be parsed
+     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     *                                                      this instance of the Java virtual machine
+     * this instance of the Java virtual machine
      */
     public static String toString(final HttpEntity entity, final int maxResultLength) throws IOException, ParseException {
         Args.notNull(entity, "HttpEntity");

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -77,7 +77,7 @@ public final class EntityUtils {
      */
     public static void consumeQuietly(final HttpEntity entity) {
         try {
-          consume(entity);
+            consume(entity);
         } catch (final IOException ignore) {
             // Ignore exception
         }
@@ -116,8 +116,8 @@ public final class EntityUtils {
      *
      * @param entity the entity to read from=
      * @return byte array containing the entity content. May be null if
-     *   {@link HttpEntity#getContent()} is null.
-     * @throws IOException if an error occurs reading the input stream
+     * {@link HttpEntity#getContent()} is null.
+     * @throws IOException              if an error occurs reading the input stream
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity) throws IOException {
@@ -140,12 +140,12 @@ public final class EntityUtils {
     /**
      * Reads the contents of an entity and return it as a byte array.
      *
-     * @param entity the entity to read from=
+     * @param entity          the entity to read from=
      * @return byte array containing the entity content. May be null if
-     *   {@link HttpEntity#getContent()} is null.
+     * {@link HttpEntity#getContent()} is null.
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
-     * @throws IOException if an error occurs reading the input stream
+     * @throws IOException              if an error occurs reading the input stream
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity, final int maxResultLength) throws IOException {
@@ -158,15 +158,16 @@ public final class EntityUtils {
             final ByteArrayBuffer buffer = new ByteArrayBuffer(Math.min(maxResultLength, contentLength));
             final byte[] tmp = new byte[DEFAULT_BYTE_BUFFER_SIZE];
             int l;
-            while ((l = inStream.read(tmp, 0, Math.min(DEFAULT_BYTE_BUFFER_SIZE, buffer.capacity() - buffer.length()))) > 0) {
+            while ((l = inStream.read(tmp)) != -1 && buffer.length() < maxResultLength) {
                 buffer.append(tmp, 0, l);
             }
+            buffer.setLength(Math.min(buffer.length(), maxResultLength));
             return buffer.toByteArray();
         }
     }
 
     private static CharArrayBuffer toCharArrayBuffer(final InputStream inStream, final int contentLength,
-            final Charset charset, final int maxResultLength) throws IOException {
+                                                     final Charset charset, final int maxResultLength) throws IOException {
         Args.notNull(inStream, "InputStream");
         Args.positive(maxResultLength, "maxResultLength");
         final Charset actualCharset = charset == null ? DEFAULT_CHARSET : charset;
@@ -194,9 +195,9 @@ public final class EntityUtils {
                 ContentType.MULTIPART_FORM_DATA,
                 ContentType.TEXT_HTML,
                 ContentType.TEXT_PLAIN,
-                ContentType.TEXT_XML };
+                ContentType.TEXT_XML};
         final HashMap<String, ContentType> map = new HashMap<>();
-        for (final ContentType contentType: contentTypes) {
+        for (final ContentType contentType : contentTypes) {
             map.put(contentType.getMimeType(), contentType);
         }
         CONTENT_TYPE_MAP = Collections.unmodifiableMap(map);
@@ -227,16 +228,16 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity must not be null
+     * @param entity         must not be null
      * @param defaultCharset character set to be applied if none found in the entity,
-     * or if the entity provided charset is invalid or not available.
+     *                       or if the entity provided charset is invalid or not available.
      * @return the entity content as a String. May be null if
-     *   {@link HttpEntity#getContent()} is null.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * {@link HttpEntity#getContent()} is null.
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named entity's charset is not available in
-     * this instance of the Java virtual machine and no defaultCharset is provided.
+     *                                                      this instance of the Java virtual machine and no defaultCharset is provided.
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset) throws IOException, ParseException {
@@ -248,18 +249,18 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity must not be null
-     * @param defaultCharset character set to be applied if none found in the entity,
-     * or if the entity provided charset is invalid or not available.
+     * @param entity          must not be null
+     * @param defaultCharset  character set to be applied if none found in the entity,
+     *                        or if the entity provided charset is invalid or not available.
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return the entity content as a String. May be null if
-     *   {@link HttpEntity#getContent()} is null.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * {@link HttpEntity#getContent()} is null.
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named entity's charset is not available in
-     * this instance of the Java virtual machine and no defaultCharset is provided.
+     *                                                      this instance of the Java virtual machine and no defaultCharset is provided.
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset, final int maxResultLength) throws IOException, ParseException {
@@ -287,15 +288,15 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity must not be null
+     * @param entity         must not be null
      * @param defaultCharset character set to be applied if none found in the entity
      * @return the entity content as a String. May be null if
-     *   {@link HttpEntity#getContent()} is null.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * {@link HttpEntity#getContent()} is null.
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
+     *                                                      this instance of the Java virtual machine
      */
     public static String toString(
             final HttpEntity entity, final String defaultCharset) throws IOException, ParseException {
@@ -307,17 +308,17 @@ public final class EntityUtils {
      * if none is found in the entity.
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
-     * @param entity must not be null
-     * @param defaultCharset character set to be applied if none found in the entity
+     * @param entity          must not be null
+     * @param defaultCharset  character set to be applied if none found in the entity
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return the entity content as a String. May be null if
-     *   {@link HttpEntity#getContent()} is null.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * {@link HttpEntity#getContent()} is null.
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
+     *                                                      this instance of the Java virtual machine
      */
     public static String toString(
             final HttpEntity entity, final String defaultCharset, final int maxResultLength) throws IOException, ParseException {
@@ -331,11 +332,11 @@ public final class EntityUtils {
      *
      * @param entity the entity to convert to a string; must not be null
      * @return String containing the content.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
+     *                                                      this instance of the Java virtual machine
      */
     public static String toString(final HttpEntity entity) throws IOException, ParseException {
         return toString(entity, DEFAULT_ENTITY_RETURN_MAX_LENGTH);
@@ -346,15 +347,15 @@ public final class EntityUtils {
      * The content is converted using the character set from the entity (if any),
      * failing that, "ISO-8859-1" is used.
      *
-     * @param entity the entity to convert to a string; must not be null
+     * @param entity          the entity to convert to a string; must not be null
      * @param maxResultLength
      *            The maximum size of the String to return; use it to guard against unreasonable or malicious processing.
      * @return String containing the content.
-     * @throws ParseException if header elements cannot be parsed
-     * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
-     * @throws IOException if an error occurs reading the input stream
+     * @throws ParseException                               if header elements cannot be parsed
+     * @throws IllegalArgumentException                     if entity is null or if content length &gt; Integer.MAX_VALUE
+     * @throws IOException                                  if an error occurs reading the input stream
      * @throws java.nio.charset.UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
+     *                                                      this instance of the Java virtual machine
      */
     public static String toString(final HttpEntity entity, final int maxResultLength) throws IOException, ParseException {
         Args.notNull(entity, "HttpEntity");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -262,6 +262,30 @@ public class TestEntityUtils {
     }
 
     @Test
+    public void testByteArrayMaxResultLengthWithNoContentLength() throws IOException {
+        byte b = 'b';
+        byte[] allBytes = new byte[5000];
+        Arrays.fill(allBytes, b);
+        final Map<Integer, byte[]> testCases = new HashMap<>();
+        testCases.put(0, new byte[]{});
+        testCases.put(2, Arrays.copyOfRange(allBytes, 0, 2));
+        testCases.put(allBytes.length, allBytes);
+        testCases.put(Integer.MAX_VALUE, allBytes);
+
+        for (final Map.Entry<Integer, byte[]> tc : testCases.entrySet()) {
+            final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(allBytes), null);
+
+            final byte[] bytes = EntityUtils.toByteArray(entity, tc.getKey());
+            final byte[] expectedBytes = tc.getValue();
+            Assertions.assertNotNull(bytes);
+            Assertions.assertEquals(expectedBytes.length, bytes.length);
+            for (int i = 0; i < expectedBytes.length; i++) {
+                Assertions.assertEquals(expectedBytes[i], bytes[i]);
+            }
+        }
+    }
+
+    @Test
     public void testStringMaxResultLength() throws IOException, ParseException {
         final String allMessage = "Message content";
         final byte[] allBytes = allMessage.getBytes(StandardCharsets.ISO_8859_1);


### PR DESCRIPTION
Fixes `EntityUtils.toByteArray(HttpEntity, int)` so that it can read entities that doesn't have a content length (chunked) and is larger than 4096 bytes.